### PR TITLE
Increase the number of system threads in golang

### DIFF
--- a/servers/go-blocking/main.go
+++ b/servers/go-blocking/main.go
@@ -14,6 +14,7 @@ import (
 
 func main() {
 	var port = flag.Int("p", 0, "port to listen on")
+	var connCount = flag.Int("c", 0, "number of connections")
 	flag.Parse()
 
 	c := make(chan os.Signal, 1)
@@ -24,7 +25,7 @@ func main() {
 		}
 	}()
 
-	runtime.GOMAXPROCS(runtime.NumCPU())
+	runtime.GOMAXPROCS(*connCount)
 	ln, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", *port))
 	if err != nil {
 		log.Printf("failed to listen on port %d: %v", port, err)
@@ -42,6 +43,7 @@ func main() {
 }
 
 func handleConnection(c net.Conn) {
+	runtime.LockOSThread()
 	f, err := c.(*net.TCPConn).File()
 	c.Close()
 	if err != nil {


### PR DESCRIPTION
Now go-blocking has a new flag that receives the number of connections to create one system thread for each connection.
